### PR TITLE
Ian - Week5 Day2 : room datasource, usecase 및 테스트 코드 작성

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'com.android.application'
     id 'kotlin-android'
+    id 'kotlin-kapt'
 }
 
 android {
@@ -29,6 +30,9 @@ android {
     kotlinOptions {
         jvmTarget = '1.8'
     }
+    buildFeatures {
+        viewBinding true
+    }
 }
 
 dependencies {
@@ -40,4 +44,14 @@ dependencies {
     testImplementation 'junit:junit:4.+'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+
+    // retrofit
+    implementation "com.squareup.retrofit2:retrofit:2.9.0"
+    implementation "com.squareup.retrofit2:converter-gson:2.9.0"
+
+    // Room
+    def room_version = "2.4.1"
+    implementation "androidx.room:room-runtime:$room_version"
+    implementation "androidx.room:room-ktx:$room_version"
+    kapt "androidx.room:room-compiler:$room_version"
 }

--- a/app/src/androidTest/java/com/survivalcoding/ifkakao/domain/usecase/GetLikeSessionUseCaseTest.kt
+++ b/app/src/androidTest/java/com/survivalcoding/ifkakao/domain/usecase/GetLikeSessionUseCaseTest.kt
@@ -1,0 +1,62 @@
+package com.survivalcoding.ifkakao.domain.usecase
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.survivalcoding.ifkakao.data.datasource.like.LikeDatabase
+import com.survivalcoding.ifkakao.data.datasource.like.LikeRoomDataSource
+import com.survivalcoding.ifkakao.data.datasource.session.local.SessionLocalDataSource
+import com.survivalcoding.ifkakao.data.repository.SessionRepositoryImpl
+import com.survivalcoding.ifkakao.domain.repository.SessionRepository
+import kotlinx.coroutines.runBlocking
+
+import org.junit.After
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import java.io.IOException
+
+class GetLikeSessionUseCaseTest {
+
+    private lateinit var useCase: GetLikeSessionUseCase
+    private lateinit var repository: SessionRepository
+    private lateinit var db: LikeDatabase
+
+    @Before
+    fun setUp() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        db = Room.inMemoryDatabaseBuilder(
+            context,
+            LikeDatabase::class.java
+        ).build()
+
+        repository =
+            SessionRepositoryImpl(SessionLocalDataSource(), LikeRoomDataSource(db.likeDao()))
+        useCase = GetLikeSessionUseCase(repository)
+    }
+
+    @After
+    @Throws(IOException::class)
+    fun tearDown() {
+        db.close()
+    }
+
+    @Test
+    fun `room 세션 좋아요 테스트`() = runBlocking {
+        Assert.assertEquals(0, useCase().size)
+
+        val sessions = repository.getSessionAll()
+
+        // 좋아요 상태가 아닌 경우 취소 무시
+        repository.unlikeSession(sessions[0])
+        Assert.assertEquals(0, useCase().size)
+
+        // 좋아요 설정
+        repository.likeSession(sessions[0])
+        Assert.assertEquals(1, useCase().size)
+
+        // 좋아요 취소
+        repository.unlikeSession(sessions[0])
+        Assert.assertEquals(0, useCase().size)
+    }
+}

--- a/app/src/main/java/com/survivalcoding/ifkakao/data/datasource/like/LikeDao.kt
+++ b/app/src/main/java/com/survivalcoding/ifkakao/data/datasource/like/LikeDao.kt
@@ -1,0 +1,20 @@
+package com.survivalcoding.ifkakao.data.datasource.like
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy.IGNORE
+import androidx.room.Query
+import com.survivalcoding.ifkakao.domain.model.Session
+
+@Dao
+interface LikeDao {
+    @Query("SELECT * FROM session")
+    suspend fun getSessionLike(): List<Session>
+
+    @Insert(onConflict = IGNORE)
+    suspend fun likeSession(session: Session)
+
+    @Delete
+    suspend fun unlikeSession(session: Session)
+}

--- a/app/src/main/java/com/survivalcoding/ifkakao/data/datasource/like/LikeDatabase.kt
+++ b/app/src/main/java/com/survivalcoding/ifkakao/data/datasource/like/LikeDatabase.kt
@@ -4,10 +4,10 @@ import androidx.room.Database
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
 import com.survivalcoding.ifkakao.domain.model.Session
-import com.survivalcoding.ifkakao.util.TypeConverter
+import com.survivalcoding.ifkakao.util.Converters
 
 @Database(entities = [Session::class], version = 1)
-@TypeConverters(value = [TypeConverter::class])
+@TypeConverters(Converters::class)
 abstract class LikeDatabase : RoomDatabase() {
     abstract fun likeDao(): LikeDao
 }

--- a/app/src/main/java/com/survivalcoding/ifkakao/data/datasource/like/LikeDatabase.kt
+++ b/app/src/main/java/com/survivalcoding/ifkakao/data/datasource/like/LikeDatabase.kt
@@ -1,0 +1,13 @@
+package com.survivalcoding.ifkakao.data.datasource.like
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+import androidx.room.TypeConverters
+import com.survivalcoding.ifkakao.domain.model.Session
+import com.survivalcoding.ifkakao.util.TypeConverter
+
+@Database(entities = [Session::class], version = 1)
+@TypeConverters(value = [TypeConverter::class])
+abstract class LikeDatabase : RoomDatabase() {
+    abstract fun likeDao(): LikeDao
+}

--- a/app/src/main/java/com/survivalcoding/ifkakao/data/datasource/like/LikeInMemoryDataSource.kt
+++ b/app/src/main/java/com/survivalcoding/ifkakao/data/datasource/like/LikeInMemoryDataSource.kt
@@ -9,7 +9,7 @@ class LikeInMemoryDataSource : LikeDataSource {
     override suspend fun getSessionLike(): List<Session> = sessions
 
     override suspend fun likeSession(session: Session) {
-        sessions.add(session)
+        if (!sessions.contains(session)) sessions.add(session)
     }
 
     override suspend fun unlikeSession(session: Session) {

--- a/app/src/main/java/com/survivalcoding/ifkakao/data/datasource/like/LikeRoomDataSource.kt
+++ b/app/src/main/java/com/survivalcoding/ifkakao/data/datasource/like/LikeRoomDataSource.kt
@@ -1,0 +1,11 @@
+package com.survivalcoding.ifkakao.data.datasource.like
+
+import com.survivalcoding.ifkakao.domain.model.Session
+
+class LikeRoomDataSource(private val dao: LikeDao) : LikeDataSource {
+    override suspend fun getSessionLike(): List<Session> = dao.getSessionLike()
+
+    override suspend fun likeSession(session: Session) = dao.likeSession(session)
+
+    override suspend fun unlikeSession(session: Session) = dao.unlikeSession(session)
+}

--- a/app/src/main/java/com/survivalcoding/ifkakao/domain/model/Session.kt
+++ b/app/src/main/java/com/survivalcoding/ifkakao/domain/model/Session.kt
@@ -1,5 +1,9 @@
 package com.survivalcoding.ifkakao.domain.model
 
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity
 data class Session(
     val categoryIdx: Int,
     val commentYn: String,
@@ -12,7 +16,7 @@ data class Session(
     val createdUserIdx: Int,
     val favoriteYn: String,
     val field: String,
-    val idx: Int,
+    @PrimaryKey val idx: Int,
     val lastModifiedDateTime: String,
     val lastModifiedUserIdx: Int,
     val linkList: LinkList,

--- a/app/src/main/java/com/survivalcoding/ifkakao/domain/usecase/GetAllSessionUseCase.kt
+++ b/app/src/main/java/com/survivalcoding/ifkakao/domain/usecase/GetAllSessionUseCase.kt
@@ -1,0 +1,7 @@
+package com.survivalcoding.ifkakao.domain.usecase
+
+import com.survivalcoding.ifkakao.domain.repository.SessionRepository
+
+class GetAllSessionUseCase(private val repository: SessionRepository) {
+    suspend operator fun invoke() = repository.getSessionAll()
+}

--- a/app/src/main/java/com/survivalcoding/ifkakao/domain/usecase/GetLikeSessionUseCase.kt
+++ b/app/src/main/java/com/survivalcoding/ifkakao/domain/usecase/GetLikeSessionUseCase.kt
@@ -1,0 +1,7 @@
+package com.survivalcoding.ifkakao.domain.usecase
+
+import com.survivalcoding.ifkakao.domain.repository.SessionRepository
+
+class GetLikeSessionUseCase(private val repository: SessionRepository) {
+    suspend operator fun invoke() = repository.getSessionLike()
+}

--- a/app/src/main/java/com/survivalcoding/ifkakao/domain/usecase/LikeSessionUseCase.kt
+++ b/app/src/main/java/com/survivalcoding/ifkakao/domain/usecase/LikeSessionUseCase.kt
@@ -1,0 +1,8 @@
+package com.survivalcoding.ifkakao.domain.usecase
+
+import com.survivalcoding.ifkakao.domain.model.Session
+import com.survivalcoding.ifkakao.domain.repository.SessionRepository
+
+class LikeSessionUseCase(private val repository: SessionRepository) {
+    suspend operator fun invoke(session: Session) = repository.likeSession(session)
+}

--- a/app/src/main/java/com/survivalcoding/ifkakao/domain/usecase/UnlikeSessionUseCase.kt
+++ b/app/src/main/java/com/survivalcoding/ifkakao/domain/usecase/UnlikeSessionUseCase.kt
@@ -1,0 +1,8 @@
+package com.survivalcoding.ifkakao.domain.usecase
+
+import com.survivalcoding.ifkakao.domain.model.Session
+import com.survivalcoding.ifkakao.domain.repository.SessionRepository
+
+class UnlikeSessionUseCase(private val repository: SessionRepository) {
+    suspend operator fun invoke(session: Session) = repository.unlikeSession(session)
+}

--- a/app/src/main/java/com/survivalcoding/ifkakao/util/Converters.kt
+++ b/app/src/main/java/com/survivalcoding/ifkakao/util/Converters.kt
@@ -7,8 +7,7 @@ import com.survivalcoding.ifkakao.domain.model.ContentsSpeaker
 import com.survivalcoding.ifkakao.domain.model.LinkList
 import com.survivalcoding.ifkakao.domain.model.RelationList
 
-@ProvidedTypeConverter
-class TypeConverter {
+class Converters {
     private val gson: Gson = Gson()
 
     @TypeConverter

--- a/app/src/main/java/com/survivalcoding/ifkakao/util/TypeConverter.kt
+++ b/app/src/main/java/com/survivalcoding/ifkakao/util/TypeConverter.kt
@@ -1,0 +1,43 @@
+package com.survivalcoding.ifkakao.util
+
+import androidx.room.ProvidedTypeConverter
+import androidx.room.TypeConverter
+import com.google.gson.Gson
+import com.survivalcoding.ifkakao.domain.model.ContentsSpeaker
+import com.survivalcoding.ifkakao.domain.model.LinkList
+import com.survivalcoding.ifkakao.domain.model.RelationList
+
+@ProvidedTypeConverter
+class TypeConverter {
+    private val gson: Gson = Gson()
+
+    @TypeConverter
+    fun fromLinkList(value: LinkList): String {
+        return gson.toJson(value)
+    }
+
+    @TypeConverter
+    fun jsonToLinkList(value: String): LinkList {
+        return gson.fromJson(value, LinkList::class.java)
+    }
+
+    @TypeConverter
+    fun fromRelationList(value: RelationList): String {
+        return gson.toJson(value)
+    }
+
+    @TypeConverter
+    fun jsonToRelationList(value: String): RelationList {
+        return gson.fromJson(value, RelationList::class.java)
+    }
+
+    @TypeConverter
+    fun fromContentsSpeakerList(value: List<ContentsSpeaker>): String {
+        return gson.toJson(value)
+    }
+
+    @TypeConverter
+    fun jsonToContentsSpeakerList(value: String): List<ContentsSpeaker> {
+        return gson.fromJson(value, Array<ContentsSpeaker>::class.java).toList()
+    }
+}

--- a/app/src/test/java/com/survivalcoding/ifkakao/domain/usecase/GetAllSessionUseCaseTest.kt
+++ b/app/src/test/java/com/survivalcoding/ifkakao/domain/usecase/GetAllSessionUseCaseTest.kt
@@ -1,0 +1,32 @@
+package com.survivalcoding.ifkakao.domain.usecase
+
+import com.survivalcoding.ifkakao.data.datasource.like.LikeInMemoryDataSource
+import com.survivalcoding.ifkakao.data.datasource.session.local.SessionLocalDataSource
+import com.survivalcoding.ifkakao.data.repository.SessionRepositoryImpl
+import com.survivalcoding.ifkakao.domain.repository.SessionRepository
+import junit.framework.Assert.assertEquals
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+class GetAllSessionUseCaseTest {
+
+    private lateinit var useCase: GetAllSessionUseCase
+    private lateinit var repository: SessionRepository
+
+    @Before
+    fun setUp() {
+        repository = SessionRepositoryImpl(SessionLocalDataSource(), LikeInMemoryDataSource())
+        useCase = GetAllSessionUseCase(repository)
+    }
+
+    @After
+    fun tearDown() {
+    }
+
+    @Test
+    fun `세션 리스트 조회 테스트`() = runBlocking {
+        assert(useCase().isNotEmpty())
+    }
+}

--- a/app/src/test/java/com/survivalcoding/ifkakao/domain/usecase/LikeSessionUseCaseTest.kt
+++ b/app/src/test/java/com/survivalcoding/ifkakao/domain/usecase/LikeSessionUseCaseTest.kt
@@ -1,0 +1,41 @@
+package com.survivalcoding.ifkakao.domain.usecase
+
+import com.survivalcoding.ifkakao.data.datasource.like.LikeInMemoryDataSource
+import com.survivalcoding.ifkakao.data.datasource.session.local.SessionLocalDataSource
+import com.survivalcoding.ifkakao.data.repository.SessionRepositoryImpl
+import com.survivalcoding.ifkakao.domain.repository.SessionRepository
+import kotlinx.coroutines.runBlocking
+
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+class LikeSessionUseCaseTest {
+
+    private lateinit var useCase: LikeSessionUseCase
+    private lateinit var repository: SessionRepository
+
+    @Before
+    fun setUp() {
+        repository = SessionRepositoryImpl(SessionLocalDataSource(), LikeInMemoryDataSource())
+        useCase = LikeSessionUseCase(repository)
+    }
+
+    @After
+    fun tearDown() {
+    }
+
+    @Test
+    fun `세션 좋아요 설정 테스트`() = runBlocking {
+        assertEquals(0, repository.getSessionLike().size)
+
+        val sessions = repository.getSessionAll()
+        useCase(sessions[0])
+        assertEquals(1, repository.getSessionLike().size)
+
+        // 이미 좋아요 설정 한 경우 무시
+        useCase(sessions[0])
+        assertEquals(1, repository.getSessionLike().size)
+    }
+}

--- a/app/src/test/java/com/survivalcoding/ifkakao/domain/usecase/UnlikeSessionUseCaseTest.kt
+++ b/app/src/test/java/com/survivalcoding/ifkakao/domain/usecase/UnlikeSessionUseCaseTest.kt
@@ -1,0 +1,47 @@
+package com.survivalcoding.ifkakao.domain.usecase
+
+import com.survivalcoding.ifkakao.data.datasource.like.LikeInMemoryDataSource
+import com.survivalcoding.ifkakao.data.datasource.session.local.SessionLocalDataSource
+import com.survivalcoding.ifkakao.data.repository.SessionRepositoryImpl
+import com.survivalcoding.ifkakao.domain.repository.SessionRepository
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.*
+
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+class UnlikeSessionUseCaseTest {
+
+    private lateinit var useCase: UnlikeSessionUseCase
+    private lateinit var repository: SessionRepository
+
+    @Before
+    fun setUp() {
+        repository = SessionRepositoryImpl(SessionLocalDataSource(), LikeInMemoryDataSource())
+        useCase = UnlikeSessionUseCase(repository)
+    }
+
+    @After
+    fun tearDown() {
+    }
+
+    @Test
+    fun `세션 좋아요 취소 테스트`() = runBlocking {
+        assertEquals(0, repository.getSessionLike().size)
+
+        val sessions = repository.getSessionAll()
+
+        // 좋아요 상태가 아닌 경우 무시
+        useCase(sessions[0])
+        assertEquals(0, repository.getSessionLike().size)
+
+        // 좋아요 설정
+        repository.likeSession(sessions[0])
+        assertEquals(1, repository.getSessionLike().size)
+
+        // 좋아요 취소
+        useCase(sessions[0])
+        assertEquals(0, repository.getSessionLike().size)
+    }
+}


### PR DESCRIPTION
- room datasource 작성
  - room이 제공하는 데이터 타입이 아닌 경우 type converter 작성 [(참고1 - 블로그)](https://leveloper.tistory.com/215), [(참고2 - 공식 문서)](https://developer.android.com/training/data-storage/room/referencing-data?hl=ko)
- usecase 작성
  - 정렬을 제외한 리스트 조회, 좋아요 추가/삭제만 작성
- 테스트 코드 작성
  - Unit Test: `LikeInMemoryDataSource` 사용
  - Android Test: `LikeRoomDataSource` 사용
    - `java.lang.IllegalArgumentException: A required type converter for Dao is missing in the database configuration.` 에러 발생
    - 해결: Converter 클래스에서 `@ProvidedTypeConverter` 삭제 [(참고1 - stack overflow)](https://stackoverflow.com/questions/67660824/type-converter-error-on-android-room-database), [(참고2 - stack overflow)](https://stackoverflow.com/questions/53114573/room-typeconverter-with-constructer)
    - `@ProvidedTypeConverter`는 runtime에 instance를 제공할 때 사용 [(참고 - 공식문서)](https://developer.android.com/reference/androidx/room/ProvidedTypeConverter?hl=en)